### PR TITLE
chore: scrub /pr-status references + fix hook regex false-positive

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A comprehensive Claude Code plugin for feature development, bug fixes, and PR wo
 - **Plan execution** - Parallel implementation via agent teams (worktrees + mailbox) or subagents (`run_in_background`), auto-selected
 - **Git worktree support** - Isolated workspaces for parallel development
 - **Pre-commit verification** - Type checking, security scans, debug code detection
-- **PR readiness checks** - CI verification, review comment polling, blocker scanning
+- **PR review verification** - SHA-anchored sticky-comment check + blocker scanning (inline `gh` ops, no slash command wrapper)
 - **Git guardrails** - Blocks direct pushes to main, warns on raw merge commands
 - **Code review agents** - Staff-level comprehensive reviews
 - **Context recovery** - Restore state after context compaction
@@ -69,8 +69,8 @@ flowchart TD
         S --> T{Approved?}
         T -->|No| U[Address feedback]
         U --> S
-        T -->|Yes| V["/pr-status"]
-        V --> W["Watch CI, find review comment, scan for blockers"]
+        T -->|Yes| V["Verify CI + SHA-anchored sticky comment"]
+        V --> W["gh pr checks --watch + match Reviewed commit: SHA to head"]
         W --> X{Blockers?}
         X -->|Yes| U
         X -->|No| Y[Merge & cleanup]
@@ -89,7 +89,7 @@ flowchart TD
 | **2. Isolate** | `using-git-worktrees` | Create isolated workspace (optional, for parallel work) |
 | **3. Plan** | `writing-plans` | Break feature into bite-sized tasks with acceptance criteria |
 | **4. Execute** | `plan-execution` | Parallel via agent teams or subagents (auto-selected) |
-| **5. PR & Merge** | `/pr-status` | Watch CI, find review comment, fix loop until ready, merge |
+| **5. PR & Merge** | Native `gh` ops | `gh pr checks --watch`, SHA-match latest sticky comment, fix loop until ready, merge |
 
 ### Bug Fix Path
 
@@ -98,7 +98,7 @@ flowchart TD
 | **1. Analyze** | `systematic-debugging` | 4-phase root cause analysis (gather, hypothesize, verify, fix) |
 | **2. Test** | `test-driven-development` | Red-green-refactor discipline |
 | **3. Commit** | N/A | Commit fix with conventional message |
-| **4. PR & Merge** | `/pr-status` | Create PR, watch CI, review comment check, merge |
+| **4. PR & Merge** | Native `gh` ops | Create PR, `gh pr checks --watch`, SHA-match sticky comment, merge |
 
 ### Git Guards
 
@@ -108,7 +108,7 @@ The plugin prevents common mistakes:
 |--------|---------|-------------------|
 | `git commit` | Blocked | Allowed |
 | `git push origin main` | Blocked | N/A |
-| `gh pr merge` | Warned (run /pr-status first) | Warned (run /pr-status first) |
+| `gh pr merge` | Warned (verify CI + SHA match) | Warned (verify CI + SHA match) |
 
 ### Execution Preference
 
@@ -122,8 +122,8 @@ When executing implementation plans (from `writing-plans` or similar), use `dev-
 ### Option 1: Direct from GitHub (Recommended)
 
 ```bash
-/plugin marketplace add tombakerjr/claude-code-pr-workflow
-/plugin install dev-workflow@claude-code-pr-workflow
+/plugin marketplace add tombakerjr/claude-code-workflows
+/plugin install dev-workflow@claude-code-workflows
 ```
 
 Then restart Claude Code.
@@ -131,8 +131,8 @@ Then restart Claude Code.
 ### Option 2: From Local Clone
 
 ```bash
-git clone https://github.com/tombakerjr/claude-code-pr-workflow.git
-/plugin marketplace add /path/to/claude-code-pr-workflow
+git clone https://github.com/tombakerjr/claude-code-workflows.git
+/plugin marketplace add /path/to/claude-code-workflows
 /plugin install dev-workflow@tombakerjr-claude-tools
 ```
 
@@ -144,7 +144,6 @@ Then restart Claude Code.
 
 | Command | Description |
 |---------|-------------|
-| `/pr-status` | **Watch CI, find review comment, scan for blockers, report readiness** |
 | `/context-recovery` | Recover git/PR state after context compaction |
 
 ### Agents
@@ -179,29 +178,32 @@ Then restart Claude Code.
 | `stop-check.sh` | Stop | Warns about uncommitted changes, open PRs, changes on main |
 | `workflow-preferences.sh` | SessionStart | Injects execution preferences (use plan-execution) |
 
-## The PR Readiness Check
+## PR Review Verification
 
-The `/pr-status` command enforces this critical workflow:
+Before merging a PR, verify the latest review comment was generated for the **current head commit**. The plugin's `claude-code-review.yml` workflow template stamps the head SHA into the comment body (`**Reviewed commit:** <short-sha>`). Downstream verification:
 
-1. **CI passes** — Watch all checks to completion with `gh pr checks --watch`
-2. **Find the review comment** — Poll until the review bot's comment from the current CI run is found
-3. **Read and assess** — Check for CRITICAL, FIX, BLOCKER, DO NOT MERGE
-4. **Report verdict** — READY TO MERGE or CHANGES NEEDED with specifics
+1. **CI passes** — `gh pr checks <pr> --watch`
+2. **SHA match** — parse `**Reviewed commit:** <short-sha>` from the latest `claude[bot]` sticky comment; compare to `gh pr view <pr> --json headRefOid -q .headRefOid`. Mismatch / missing / null → wait for next run (retry 3× with 5s backoff for replication lag).
+3. **Assess** — scan for CRITICAL / FIX / BLOCKER markers.
+4. **Verdict** — READY TO MERGE or CHANGES NEEDED.
 
-**Why poll for the review comment?** The review workflow ALWAYS posts a comment (either approving or requesting changes). The absence of this comment is NOT tacit approval — `/pr-status` polls with timestamp validation to ensure no review feedback is missed.
+**Why SHA match instead of timestamp polling?** Timestamp arithmetic is brittle under GitHub's distributed clock skew and silently fails when CI is re-run without a fresh push (the old comment still passes a timestamp filter). The SHA stamp is direct and unambiguous. The review workflow ALWAYS posts a comment — never treat absence or staleness as tacit approval.
+
+The `plan-execution` skill runs this inline as part of its final fix-loop. Project-specific bits (bot identifier, comment format, repo quirks) belong in each consuming project's CLAUDE.md and per-project memory.
 
 ## Usage Examples
 
 ### Checking PR Readiness
 ```
 > Is my PR ready to merge?
-# Claude runs /pr-status — watches CI, finds review comment, reports verdict
+# Claude runs gh pr checks --watch, then SHA-matches the latest sticky review comment
+# against PR head, then reports verdict (READY TO MERGE | CHANGES NEEDED)
 ```
 
 ### Merging a PR
 ```
 > Merge my PR
-# Claude runs /pr-status first, then merges if READY TO MERGE
+# Claude verifies readiness (CI + SHA match) first, then merges if READY TO MERGE
 ```
 
 ### Code Review

--- a/hooks/git-guard.py
+++ b/hooks/git-guard.py
@@ -79,8 +79,10 @@ def main():
             print("Or use /feature-start if available", file=sys.stderr)
             sys.exit(2)
 
-    # Warn on gh pr merge — remind about CI + review-comment SHA verification
-    if re.search(r'gh\s+pr\s+merge', command):
+    # Warn on gh pr merge — remind about CI + review-comment SHA verification.
+    # Anchor to start-of-command or shell-operator boundary to avoid false positives
+    # on commit messages or other strings that mention the command verbatim.
+    if re.search(r'(?:^|&&|;|\|)\s*gh\s+pr\s+merge', command):
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/hooks/git-guard.py
+++ b/hooks/git-guard.py
@@ -6,7 +6,7 @@ Blocks dangerous git operations and warns on PR merges.
 This hook scans bash commands and:
 1. BLOCKS direct pushes to main/master branches
 2. BLOCKS commits when on main/master branch
-3. WARNS when using raw `gh pr merge` (recommends running /pr-status first)
+3. WARNS when using raw `gh pr merge` (reminds about CI + review-comment SHA verification)
 
 Usage: Configure in hooks/hooks.json
 """
@@ -79,18 +79,20 @@ def main():
             print("Or use /feature-start if available", file=sys.stderr)
             sys.exit(2)
 
-    # Warn on gh pr merge without running /pr-status first
+    # Warn on gh pr merge — remind about CI + review-comment SHA verification
     if re.search(r'gh\s+pr\s+merge', command):
         output = {
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",
                 "additionalContext": (
-                    "WARNING: You are merging a PR. Did you run /pr-status first?\n"
-                    "1) Wait for CI to pass\n"
-                    "2) Wait for the review comment from the current CI run\n"
-                    "3) Read and assess all comments for blockers\n"
-                    "4) Only merge when /pr-status reports READY TO MERGE\n"
-                    "Run /pr-status before merging."
+                    "WARNING: You are merging a PR. Did you verify it's ready?\n"
+                    "1) CI passed: `gh pr checks <pr> --watch`\n"
+                    "2) Latest sticky review comment SHA matches PR head:\n"
+                    "   parse `**Reviewed commit:** <short-sha>` from the latest\n"
+                    "   claude[bot] comment; compare to `gh pr view <pr> --json headRefOid`\n"
+                    "3) Review has no CRITICAL / FIX / BLOCKER items\n"
+                    "See the project's CLAUDE.md / per-project memory for the full\n"
+                    "SHA-anchored verification protocol."
                 )
             }
         }


### PR DESCRIPTION
## Summary

Follow-up cleanup to #16. Two surfaces still referenced `/pr-status`, plus a regex bug in the hook itself surfaced during the cleanup commit.

## Changes

### 1. `hooks/git-guard.py` — warning text
The hook globally warned on PR-merge invocations, telling Claude to run `/pr-status` first — but that command no longer exists. Rewritten to describe the SHA-anchored verification protocol inline (CI watch, sticky-comment SHA match against `headRefOid`, blocker scan) and point at project CLAUDE.md / memory for full details.

### 2. `hooks/git-guard.py` — anchor the warning regex
Discovered the hard way: the prior regex matched the literal command substring anywhere in the command, including inside HEREDOC bodies. A `git commit -m "$(cat <<EOF ... gh pr merge ... EOF)"` would falsely trigger the merge warning. Mirror the anchor pattern already used by the on-main commit-block check (`(?:^|&&|;|\|)` before the match) so only real invocations trigger.

### 3. `README.md` — broad cleanup
- Drop `/pr-status` from the Slash Commands table (only `/context-recovery` remains).
- Feature Development Path + Bug Fix Path tables now reference native `gh` ops instead of `/pr-status`.
- Mermaid flowchart's merge subgraph updated.
- Git Guards table updated to reflect the new warning text.
- "The PR Readiness Check" section rewritten into "PR Review Verification" with the SHA-anchored protocol (matching CLAUDE.md and `plan-execution` SKILL).
- Usage Examples describe the inline flow.
- Installation Options use the new canonical repo name `claude-code-workflows` (was `claude-code-pr-workflow`; GitHub redirects, but the canonical URL is the rename).

## Why this isn't in #16

The hook fired during this session as I was merging #16, surfacing the stale warning. The README staleness was noted as out of scope at the time. The regex false-positive only became visible when *this* commit's message body (which references the merge command verbatim) triggered the hook on an unrelated `git commit` — caught and fixed in the same PR.

## Test plan
- [ ] CI passes (no claude-review feedback expected — this is the workflow-file repo, but no workflow YAML changes here)
- [ ] After merge: next `gh pr merge ...` invocation surfaces the new warning text
- [ ] After merge: `git commit -m "...mentions gh pr merge..."` does NOT trigger the warning
- [ ] After merge + `claude plugin update`: warning behavior takes effect locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)