### PR TITLE
feat(hooks): one-shot PR-merge warning per session+PR

### DIFF
--- a/hooks/git-guard.py
+++ b/hooks/git-guard.py
@@ -6,14 +6,24 @@ Blocks dangerous git operations and warns on PR merges.
 This hook scans bash commands and:
 1. BLOCKS direct pushes to main/master branches
 2. BLOCKS commits when on main/master branch
-3. WARNS when using raw `gh pr merge` (reminds about CI + review-comment SHA verification)
+3. WARNS on first PR-merge attempt per session+PR (BLOCK-then-allow-on-retry).
+   After the warning fires once for a given (session, PR), subsequent attempts
+   in the same session proceed silently. Pattern mirrors anthropics/claude-code's
+   security-guidance plugin: warn without permanently preventing — confirm and
+   try again.
 
 Usage: Configure in hooks/hooks.json
 """
 import json
-import sys
+import os
+import random
 import re
 import subprocess
+import sys
+from datetime import datetime
+
+
+WARNING_STATE_DIR = os.path.expanduser("~/.claude")
 
 
 def parse_git_c_path(command):
@@ -40,6 +50,78 @@ def get_current_branch(cwd=None):
         return None
 
 
+def get_repo_slug(cwd=None):
+    """Get current repo's owner/name slug from gh CLI, or None on failure."""
+    try:
+        cmd = ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=5, cwd=cwd
+        )
+        return result.stdout.strip() if result.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def warning_state_file(session_id):
+    """Per-session warning-state file path."""
+    return os.path.join(WARNING_STATE_DIR, f"git_guard_warnings_{session_id}.json")
+
+
+def load_shown_warnings(session_id):
+    """Load the set of warning keys already shown in this session."""
+    path = warning_state_file(session_id)
+    if not os.path.exists(path):
+        return set()
+    try:
+        with open(path) as f:
+            return set(json.load(f))
+    except (json.JSONDecodeError, IOError):
+        return set()
+
+
+def save_shown_warnings(session_id, shown):
+    """Persist the set of warning keys shown in this session."""
+    path = warning_state_file(session_id)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(list(shown), f)
+    except IOError:
+        pass  # fail silently — state is best-effort
+
+
+def cleanup_old_state_files():
+    """Remove warning-state files older than 30 days. Called probabilistically."""
+    try:
+        if not os.path.exists(WARNING_STATE_DIR):
+            return
+        cutoff = datetime.now().timestamp() - (30 * 24 * 60 * 60)
+        for filename in os.listdir(WARNING_STATE_DIR):
+            if filename.startswith("git_guard_warnings_") and filename.endswith(".json"):
+                file_path = os.path.join(WARNING_STATE_DIR, filename)
+                try:
+                    if os.path.getmtime(file_path) < cutoff:
+                        os.remove(file_path)
+                except (OSError, IOError):
+                    pass
+    except Exception:
+        pass
+
+
+def merge_warning_key(command):
+    """Build the dedup key for a PR-merge warning, based on repo+PR if available."""
+    # Extract PR number from the command if present (gh pr merge <num> ...)
+    pr_match = re.search(r'gh\s+pr\s+merge\s+(\d+)', command)
+    pr_part = pr_match.group(1) if pr_match else "current"
+    # Extract repo slug — prefer --repo flag, fall back to current repo, then unknown
+    repo_match = re.search(r'--repo\s+(\S+)', command)
+    if repo_match:
+        repo_part = repo_match.group(1)
+    else:
+        repo_part = get_repo_slug() or "unknown-repo"
+    return f"merge:{repo_part}/{pr_part}"
+
+
 def main():
     try:
         input_data = json.load(sys.stdin)
@@ -51,6 +133,11 @@ def main():
         sys.exit(0)
 
     command = input_data.get("tool_input", {}).get("command", "")
+    session_id = input_data.get("session_id", "default")
+
+    # Periodically clean up old state files (10% chance per invocation)
+    if random.random() < 0.1:
+        cleanup_old_state_files()
 
     # Patterns that should be blocked entirely
     blocked = [
@@ -79,26 +166,31 @@ def main():
             print("Or use /feature-start if available", file=sys.stderr)
             sys.exit(2)
 
-    # Warn on gh pr merge — remind about CI + review-comment SHA verification.
+    # Warn on PR-merge — remind about CI + review-comment SHA verification.
     # Anchor to start-of-command or shell-operator boundary to avoid false positives
     # on commit messages or other strings that mention the command verbatim.
+    # First fire per (session, repo, PR): WARN + BLOCK. Retry: silent allow.
     if re.search(r'(?:^|&&|;|\|)\s*gh\s+pr\s+merge', command):
-        output = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "additionalContext": (
-                    "WARNING: You are merging a PR. Did you verify it's ready?\n"
-                    "1) CI passed: `gh pr checks <pr> --watch`\n"
-                    "2) Latest sticky review comment SHA matches PR head:\n"
-                    "   parse `**Reviewed commit:** <short-sha>` from the latest\n"
-                    "   claude[bot] comment; compare to `gh pr view <pr> --json headRefOid`\n"
-                    "3) Review has no CRITICAL / FIX / BLOCKER items\n"
-                    "See the project's CLAUDE.md / per-project memory for the full\n"
-                    "SHA-anchored verification protocol."
-                )
-            }
-        }
-        print(json.dumps(output))
+        key = merge_warning_key(command)
+        shown = load_shown_warnings(session_id)
+        if key not in shown:
+            shown.add(key)
+            save_shown_warnings(session_id, shown)
+            print(
+                "WARNING: You are merging a PR. Did you verify it's ready?\n"
+                "1) CI passed: `gh pr checks <pr> --watch`\n"
+                "2) Latest sticky review comment SHA matches PR head:\n"
+                "   parse `**Reviewed commit:** <short-sha>` from the latest\n"
+                "   claude[bot] comment; compare to `gh pr view <pr> --json headRefOid`\n"
+                "3) Review has no CRITICAL / FIX / BLOCKER items\n"
+                "See the project's CLAUDE.md / per-project memory for the full\n"
+                "SHA-anchored verification protocol.\n"
+                "\n"
+                "If verified, re-issue the command to proceed.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        # Already warned for this (session, repo, PR) — allow silently.
 
     sys.exit(0)
 


### PR DESCRIPTION
## Summary

Adopt the dedup pattern from `anthropics/claude-code`'s `security-guidance` plugin so the merge-readiness reminder fires once per logical unit of work (session + repo + PR) instead of every single time. Before: noisy and easy to start ignoring. After: see it once, confirm, retry — quiet on subsequent attempts.

## Mechanism

Mirrors `plugins/security-guidance/hooks/security_reminder_hook.py`:

- **State file**: `~/.claude/git_guard_warnings_{session_id}.json`, holding a set of warning keys already shown this session.
- **`session_id`** pulled from the hook's stdin JSON input.
- **Warning key**: `merge:<owner>/<repo>/<pr_num>` — extracted from the command (`--repo` flag if present, else current repo via `gh repo view`; PR number from arg, or `"current"` if invoked without one).
- **First detection of a key**: print reminder to stderr + `sys.exit(2)` (BLOCK). Subsequent detections of the same key in the same session: silent allow.
- **Periodic cleanup**: 10% chance per invocation removes state files older than 30 days (matches the security plugin's housekeeping).

## Behavior change

The reminder output switched from `additionalContext` (informational, never blocks) to **stderr + exit 2** (BLOCK on first attempt). This matches the reference implementation and makes "confirm and retry" the explicit gate.

## What's not changed

The on-main commit-block and direct-push-to-main blocks are unchanged — those are absolute, not dedupable.

## Why

`additionalContext` reminders fire every single invocation. When Claude (or me) makes multiple PR-merge attempts in a session — across different PRs, or retrying after fixes — every single attempt printed the same long reminder, which trains the eye to ignore it. The block-then-allow pattern forces one explicit acknowledgment per real unit of work, then gets out of the way.

## Test plan
- [ ] Merge a PR: first `gh pr merge <num>` invocation prints reminder and is blocked. Re-issue → succeeds silently.
- [ ] Merge a second PR in the same session: fresh reminder + block on first attempt (different `pr_num` → different key). Re-issue → succeeds.
- [ ] After 30+ days: state file from a prior session gets cleaned up on a future invocation (10% chance per run).
- [ ] State directory: `~/.claude/git_guard_warnings_<session>.json` exists after first warning and contains the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)