### PR TITLE
fix(hooks): extract pr number from any position in gh pr merge

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,23 +1,31 @@
+
+
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   powershell          python              python_jedi         r                   rego
-#   ruby                ruby_solargraph     rust                scala               swift
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
-#   - csharp: Requires the presence of a .sln file in the project folder.
-#   - pascal: Requires Free Pascal Compiler (fpc) and optionally Lazarus.
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
 # When using multiple languages, the first language server that supports a given file will be used for that file.
 # The first language is the default language and the respective language server will be used as a fallback.
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
@@ -31,8 +39,9 @@ encoding: "utf-8"
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore in all projects
-# same syntax as gitignore, so you can use * and **
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -40,50 +49,93 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "claude-code-workflows"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/hooks/git-guard.py
+++ b/hooks/git-guard.py
@@ -18,6 +18,7 @@ import json
 import os
 import random
 import re
+import shlex
 import subprocess
 import sys
 from datetime import datetime
@@ -109,15 +110,49 @@ def cleanup_old_state_files():
 
 
 def merge_warning_key(command):
-    """Build the dedup key for a PR-merge warning, based on repo+PR if available."""
-    # Extract PR number from the command if present (gh pr merge <num> ...)
-    pr_match = re.search(r'gh\s+pr\s+merge\s+(\d+)', command)
-    pr_part = pr_match.group(1) if pr_match else "current"
-    # Extract repo slug — prefer --repo flag, fall back to current repo, then unknown
-    repo_match = re.search(r'--repo\s+(\S+)', command)
-    if repo_match:
-        repo_part = repo_match.group(1)
-    else:
+    """Build the dedup key for a PR-merge warning, based on repo+PR if available.
+
+    The PR number can appear anywhere after the `merge` subcommand — before
+    or after flags like `--squash` or `--repo owner/repo` — so we tokenize
+    rather than rely on positional regex. The first bare-integer token after
+    `merge` is the PR number; if none is present, `gh pr merge` operates on
+    the current branch's PR and we use "current" as the key part.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    pr_part = "current"
+    repo_part = None
+
+    # Only enter arg-parsing after seeing the full `gh pr merge` subcommand
+    # sequence. Without this, compound commands like `git merge 123 && gh pr
+    # merge` would pick up `123` from the `git merge` operand.
+    merge_idx = -1
+    for j in range(len(tokens) - 2):
+        if tokens[j] == "gh" and tokens[j + 1] == "pr" and tokens[j + 2] == "merge":
+            merge_idx = j + 2
+            break
+    if merge_idx == -1:
+        return f"merge:{get_repo_slug() or 'unknown-repo'}/current"
+
+    i = merge_idx + 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--repo" and i + 1 < len(tokens):
+            repo_part = tokens[i + 1]
+            i += 2
+            continue
+        if tok.startswith("--repo="):
+            repo_part = tok.split("=", 1)[1]
+            i += 1
+            continue
+        if pr_part == "current" and tok.isdigit():
+            pr_part = tok
+        i += 1
+
+    if not repo_part:
         repo_part = get_repo_slug() or "unknown-repo"
     return f"merge:{repo_part}/{pr_part}"
 

--- a/hooks/test_git_guard.py
+++ b/hooks/test_git_guard.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for git-guard hook helpers.
+
+Run with: python3 -m unittest hooks/test_git_guard.py
+
+Tests use stdlib only (no pytest required) so they can run anywhere
+Python 3 is available.
+"""
+import importlib.util
+import os
+import unittest
+from unittest.mock import patch
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "git_guard", os.path.join(_HERE, "git-guard.py")
+)
+git_guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(git_guard)
+
+
+class MergeWarningKeyTests(unittest.TestCase):
+    """Covers the PR-number / repo-slug extraction. The key shape is
+    `merge:<owner/repo>/<pr_num>`, and the same (session, key) tuple
+    must collapse to one warning."""
+
+    def _key(self, command):
+        # Stub get_repo_slug so tests don't depend on a real gh/git env
+        with patch.object(git_guard, "get_repo_slug", return_value="owner/repo"):
+            return git_guard.merge_warning_key(command)
+
+    def test_pr_number_immediately_after_merge(self):
+        self.assertEqual(self._key("gh pr merge 123"), "merge:owner/repo/123")
+
+    def test_pr_number_after_flag(self):
+        self.assertEqual(self._key("gh pr merge --squash 123"), "merge:owner/repo/123")
+
+    def test_pr_number_after_repo_flag(self):
+        self.assertEqual(
+            self._key("gh pr merge --repo other/repo 99"),
+            "merge:other/repo/99",
+        )
+
+    def test_pr_number_with_repo_equals_form(self):
+        self.assertEqual(
+            self._key("gh pr merge --repo=other/repo 42"),
+            "merge:other/repo/42",
+        )
+
+    def test_pr_number_before_flags(self):
+        self.assertEqual(
+            self._key("gh pr merge 7 --squash --delete-branch"),
+            "merge:owner/repo/7",
+        )
+
+    def test_no_pr_number_uses_current(self):
+        self.assertEqual(
+            self._key("gh pr merge --squash --auto"),
+            "merge:owner/repo/current",
+        )
+
+    def test_no_pr_number_with_repo_uses_current(self):
+        self.assertEqual(
+            self._key("gh pr merge --repo other/repo --squash"),
+            "merge:other/repo/current",
+        )
+
+    def test_distinct_prs_in_same_repo_produce_distinct_keys(self):
+        a = self._key("gh pr merge --squash 11")
+        b = self._key("gh pr merge --squash 22")
+        self.assertNotEqual(a, b)
+
+    def test_compound_command_with_preceding_git_merge_ignores_unrelated_int(self):
+        # Regression: a `merge` token from `git merge` upstream of `gh pr merge`
+        # must not be picked up as the PR number. Only the gh→pr→merge sequence
+        # opens the arg-parsing window.
+        self.assertEqual(
+            self._key("git merge 123 && gh pr merge"),
+            "merge:owner/repo/current",
+        )
+
+    def test_compound_command_with_following_pr_number(self):
+        self.assertEqual(
+            self._key("git merge 123 && gh pr merge 456"),
+            "merge:owner/repo/456",
+        )
+
+    def test_unrelated_command_with_merge_token_returns_current(self):
+        # If `gh pr merge` is not in the command at all, we should not
+        # synthesize a PR number from some other `merge` usage.
+        self.assertEqual(
+            self._key("git merge feature/foo"),
+            "merge:owner/repo/current",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to the warn-once hook (PR #19, released as v2.4.0). The dedup key regex `r'gh\s+pr\s+merge\s+(\d+)'` only matched a digit immediately after `merge`, so flag-first invocations like `gh pr merge --squash 123` and `gh pr merge --repo other/repo 99` silently collapsed to a `current` key and shared one dedup slot per repo — the second flag-first PR you merge would skip the warning. Switch to a shlex-based token scan that requires the full `gh → pr → merge` sequence (so a preceding `git merge 123 && …` doesn't pollute the PR-number scan), pulls `--repo` / `--repo=` value separately, and treats the first bare-integer token after `merge` as the PR number.

Also adds `hooks/test_git_guard.py` — stdlib-only unittest cases covering the regression scenarios plus the no-PR-number, distinct-PRs, and compound-command branches. Run with `python3 -m unittest hooks.test_git_guard`.

Includes a chore commit refreshing `.serena/project.yml` from the upstream template (no behavioral change; new fields at defaults — staged so future sessions don't perpetually surface the same diff in `git status`).

## Test plan

- [ ] `python3 -m unittest hooks.test_git_guard` — all 11 cases pass
- [ ] In a fresh session, `gh pr merge --squash 11` blocks once with the reminder
- [ ] In the same session, `gh pr merge --squash 22` ALSO blocks once (distinct dedup key, was silently skipped before)
- [ ] Second attempt at `gh pr merge --squash 11` proceeds silently (dedup still works for repeated PR)
- [ ] `git merge 123 && gh pr merge` does NOT incorrectly key on `123`