### PR TITLE
feat(hooks): inject current local time on every user prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,9 @@ claude-code-pr-workflow/
 │   ├── run-hook.cmd           # Cross-platform wrapper
 │   ├── git-guard.py           # PreToolUse: block main push
 │   ├── task-completed-gate.py # TaskCompleted: review gate for agent teams
-│   └── stop-check.sh          # Stop: warn on uncommitted
+│   ├── stop-check.sh          # Stop: warn on uncommitted
+│   ├── workflow-preferences.sh # SessionStart: execution preferences
+│   └── inject-current-time.py # UserPromptSubmit: wall-clock awareness
 ├── CLAUDE.md
 └── README.md
 ```

--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ Then restart Claude Code.
 | `task-completed-gate.py` | TaskCompleted | Prevents implementation tasks from being marked complete before review |
 | `stop-check.sh` | Stop | Warns about uncommitted changes, open PRs, changes on main |
 | `workflow-preferences.sh` | SessionStart | Injects execution preferences (use plan-execution) |
+| `inject-current-time.py` | UserPromptSubmit | Injects current local time on every prompt (~12-25 tokens). Optional late-hour and US-DST nudges via env vars — see below |
+
+#### Time-injection hook
+
+`inject-current-time.py` runs on every user prompt and prepends a bracketed system note like `[current time: 2026-05-26 14:04 EDT]`. This closes the wall-clock-awareness gap caused by Claude's training cutoff — without it, the model cannot reason reliably about "this morning" vs. "six months ago," whether a release / changelog entry is recent, or judge urgency.
+
+Two optional suffixes, both off by default and opt-in via environment variables (set in your shell rc):
+
+| Env var | Effect |
+|---------|--------|
+| `CLAUDE_TIME_LATE_START` + `CLAUDE_TIME_LATE_END` | When both are set to integer hours and the current hour falls in `[start, end)`, the note gets a `past late-hour wrap-up cutoff` suffix. Useful as a self-care nudge for late-night coders. E.g. `CLAUDE_TIME_LATE_START=2 CLAUDE_TIME_LATE_END=5` |
+| `CLAUDE_TIME_DST_REGION=us` | Adds a US DST transition reminder within ±3 days of the spring-forward (2nd Sunday of March) and fall-back (1st Sunday of November) transitions. Only `us` is implemented. |
+
+The hook is pure Python stdlib, ~5 ms per invocation. To disable entirely, comment out its entry in `hooks/hooks.json` after install or override at the user-settings level.
 
 ## PR Review Verification
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -44,6 +44,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" inject-current-time.py",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/inject-current-time.py
+++ b/hooks/inject-current-time.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+inject-current-time — UserPromptSubmit hook
+
+Emits a small bracketed system note on every user message with the current
+local time. Closes the wall-clock-awareness gap: Claude's training data
+has a fixed cutoff, so without an injection like this it cannot
+distinguish "this morning" from "six months ago," reason about whether
+a release / deploy / changelog entry is recent, or judge urgency.
+
+Output format:
+    [current time: 2026-05-26 14:04 EDT]
+    [current time: 2026-03-08 03:15 EST — past late-hour wrap-up cutoff]
+    [current time: 2026-03-08 03:15 EST — past late-hour wrap-up cutoff;
+        DST spring-forward TONIGHT — clocks jump 2 AM → 3 AM]
+
+Cost: ~12-25 tokens per turn depending on which suffixes fire.
+
+Optional suffixes (off by default — opt in via env vars):
+
+    CLAUDE_TIME_LATE_START=2   start hour (24h) of "wrap up" window
+    CLAUDE_TIME_LATE_END=5     end hour (exclusive) of the window
+
+When BOTH are set to integers and the current hour falls in
+[LATE_START, LATE_END), the note gets a "past late-hour wrap-up cutoff"
+suffix. Useful as a self-care nudge for late-night coders.
+
+    CLAUDE_TIME_DST_REGION=us  enable US DST transition nudges
+
+When set to "us", the note gets a transition reminder within ±3 days of
+the second-Sunday-in-March / first-Sunday-in-November US DST changes.
+Only "us" is implemented; non-US regions emit no DST suffix.
+"""
+import datetime
+import os
+import sys
+
+
+DST_WINDOW_DAYS = 3
+
+
+def _env_int(name):
+    """Return env var as int, or None if unset / not parseable."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def late_hour_suffix(now):
+    """Suffix when inside the user-configured late-hour window. Off unless
+    both CLAUDE_TIME_LATE_START and CLAUDE_TIME_LATE_END are set.
+
+    The window is half-open `[start, end)` — `start` hour fires, `end`
+    hour does not. So `start == end` is a deliberately empty window
+    (no hour matches), not a single-hour window. For "fire at hour N
+    only" set `START=N END=N+1`. For "fire at hour N and onward through
+    M (inclusive)" set `START=N END=M+1`.
+
+    Supports midnight-spanning windows (start > end), so the natural
+    "late night" config CLAUDE_TIME_LATE_START=22 CLAUDE_TIME_LATE_END=3
+    fires at 22:00, 23:00, 00:00, 01:00, 02:00.
+    """
+    start = _env_int("CLAUDE_TIME_LATE_START")
+    end = _env_int("CLAUDE_TIME_LATE_END")
+    if start is None or end is None:
+        return ""
+    h = now.hour
+    if start <= end:
+        in_window = start <= h < end
+    else:
+        in_window = h >= start or h < end
+    return "past late-hour wrap-up cutoff" if in_window else ""
+
+
+def closest_us_dst_transition(today_date):
+    """Return (transition_date, kind, days_to) for the US DST transition
+    closest to today_date — past or future.
+
+    kind is "spring forward" (clocks +1h, lose an hour of sleep) or
+    "fall back" (clocks -1h, gain an hour). Uses the US rule: 2nd
+    Sunday of March / 1st Sunday of November.
+
+    Considering the prior, current, and next years (three in total)
+    ensures we don't lose the just-passed transition case when computing
+    days_to near a year boundary.
+    """
+    candidates = []
+    for year in (today_date.year - 1, today_date.year, today_date.year + 1):
+        march_1 = datetime.date(year, 3, 1)
+        spring = march_1 + datetime.timedelta(
+            days=((6 - march_1.weekday()) % 7) + 7
+        )
+        nov_1 = datetime.date(year, 11, 1)
+        fall = nov_1 + datetime.timedelta(days=(6 - nov_1.weekday()) % 7)
+        candidates.append((spring, "spring forward"))
+        candidates.append((fall, "fall back"))
+
+    transition, kind = min(
+        candidates, key=lambda t: abs((t[0] - today_date).days)
+    )
+    return transition, kind, (transition - today_date).days
+
+
+def dst_suffix(now):
+    """US DST nudge string, within ±DST_WINDOW_DAYS of the closest
+    transition. Off unless CLAUDE_TIME_DST_REGION=us.
+
+    Takes the full `now` datetime (not just date) because on transition
+    day itself the message needs to flip from future-tense ("TONIGHT")
+    to past-tense once 2 AM local has passed.
+    """
+    if os.environ.get("CLAUDE_TIME_DST_REGION", "").lower() != "us":
+        return ""
+
+    transition, kind, days_to = closest_us_dst_transition(now.date())
+    if abs(days_to) > DST_WINDOW_DAYS:
+        return ""
+
+    # On the transition day, after 2 AM local the change has already
+    # happened — treat it as same-day-past rather than upcoming.
+    transition_passed = days_to == 0 and now.hour >= 2
+
+    if kind == "spring forward":
+        if days_to > 0:
+            return (
+                f"DST spring-forward in {days_to}d — clocks ahead 1h Sunday "
+                f"at 2 AM, aim to wind down a little earlier each night"
+            )
+        if days_to == 0 and not transition_passed:
+            return "DST spring-forward TONIGHT — clocks jump 2 AM → 3 AM"
+        if transition_passed:
+            return (
+                "DST spring-forward happened earlier today — clocks already "
+                "at +1h, body adjusting"
+            )
+        return (
+            f"DST started {-days_to}d ago — body still adjusting, expect "
+            f"shorter / lighter sleep for a few days"
+        )
+
+    # fall back
+    if days_to > 0:
+        return (
+            f"DST fall-back in {days_to}d — clocks back 1h Sunday at 2 AM, "
+            f"bonus hour of sleep available (use it)"
+        )
+    if days_to == 0 and not transition_passed:
+        return "DST fall-back TONIGHT — clocks roll 2 AM → 1 AM"
+    if transition_passed:
+        return (
+            "DST fall-back happened earlier today — clocks already at -1h, "
+            "earlier sunsets from here"
+        )
+    return (
+        f"DST ended {-days_to}d ago — earlier sunsets, body still adjusting"
+    )
+
+
+def render(now):
+    """Build the full bracketed note.
+
+    Not strictly pure — the suffix helpers read CLAUDE_TIME_* env vars —
+    but easy to unit-test by patching `os.environ` (see test file).
+    """
+    tz_name = now.tzname() or ""
+    time_str = now.strftime("%Y-%m-%d %H:%M") + (f" {tz_name}" if tz_name else "")
+
+    suffixes = []
+    late = late_hour_suffix(now)
+    if late:
+        suffixes.append(late)
+    dst = dst_suffix(now)
+    if dst:
+        suffixes.append(dst)
+
+    suffix_text = (" — " + "; ".join(suffixes)) if suffixes else ""
+    return f"[current time: {time_str}{suffix_text}]"
+
+
+def main():
+    # Drain stdin so Claude Code's write to the hook does not race a closed
+    # pipe. UserPromptSubmit hooks receive a JSON payload; we don't use it,
+    # but we still need to consume it. Matches the pattern in git-guard.py
+    # and task-completed-gate.py.
+    try:
+        sys.stdin.read()
+    except (OSError, ValueError):
+        pass
+    now = datetime.datetime.now().astimezone()
+    print(render(now))
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/test_inject_current_time.py
+++ b/hooks/test_inject_current_time.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Unit tests for inject-current-time hook helpers.
+
+Run with: python3 -m unittest hooks/test_inject_current_time.py
+
+Stdlib only — no pytest required.
+"""
+import datetime
+import importlib.util
+import os
+import unittest
+from unittest.mock import patch
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "inject_current_time", os.path.join(_HERE, "inject-current-time.py")
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _aware(year, month, day, hour, minute=0, tz="EST"):
+    """Build an aware datetime with a fixed tzname for stable assertions."""
+    offset = datetime.timezone(datetime.timedelta(hours=-5), name=tz)
+    return datetime.datetime(year, month, day, hour, minute, tzinfo=offset)
+
+
+class RenderTests(unittest.TestCase):
+    """End-to-end of the bracketed note produced for a given datetime."""
+
+    def _render_clean_env(self, now, env=None):
+        with patch.dict(os.environ, env or {}, clear=True):
+            return mod.render(now)
+
+    def test_default_output_is_just_bracketed_time(self):
+        now = _aware(2026, 5, 26, 14, 4)
+        self.assertEqual(
+            self._render_clean_env(now),
+            "[current time: 2026-05-26 14:04 EST]",
+        )
+
+    def test_late_hour_suffix_requires_both_env_vars(self):
+        now = _aware(2026, 5, 26, 3, 0)
+        bare = "[current time: 2026-05-26 03:00 EST]"
+        # Only start set — must not fire (incomplete config)
+        self.assertEqual(
+            self._render_clean_env(now, {"CLAUDE_TIME_LATE_START": "2"}),
+            bare,
+        )
+        # Only end set (symmetric case) — must not fire either
+        self.assertEqual(
+            self._render_clean_env(now, {"CLAUDE_TIME_LATE_END": "5"}),
+            bare,
+        )
+        # Both set, in window — fires
+        self.assertIn(
+            "past late-hour wrap-up cutoff",
+            self._render_clean_env(
+                now, {"CLAUDE_TIME_LATE_START": "2", "CLAUDE_TIME_LATE_END": "5"}
+            ),
+        )
+
+    def test_late_hour_window_is_half_open(self):
+        env = {"CLAUDE_TIME_LATE_START": "2", "CLAUDE_TIME_LATE_END": "5"}
+        # Start hour: included
+        self.assertIn(
+            "wrap-up", self._render_clean_env(_aware(2026, 5, 26, 2, 0), env)
+        )
+        # End hour: excluded
+        self.assertNotIn(
+            "wrap-up", self._render_clean_env(_aware(2026, 5, 26, 5, 0), env)
+        )
+        # Outside: excluded
+        self.assertNotIn(
+            "wrap-up", self._render_clean_env(_aware(2026, 5, 26, 14, 0), env)
+        )
+
+    def test_late_hour_env_var_non_int_is_ignored(self):
+        env = {"CLAUDE_TIME_LATE_START": "two", "CLAUDE_TIME_LATE_END": "5"}
+        self.assertNotIn(
+            "wrap-up", self._render_clean_env(_aware(2026, 5, 26, 3, 0), env)
+        )
+
+    def test_equal_start_and_end_is_empty_window(self):
+        # Half-open [3, 3) — deliberately empty, not a single-hour window
+        env = {"CLAUDE_TIME_LATE_START": "3", "CLAUDE_TIME_LATE_END": "3"}
+        for hour in (2, 3, 4):
+            with self.subTest(hour=hour):
+                self.assertNotIn(
+                    "wrap-up",
+                    self._render_clean_env(_aware(2026, 5, 26, hour, 0), env),
+                )
+
+    def test_midnight_spanning_window_fires_correctly(self):
+        # "Late night" config: 22:00 → 03:00 spans midnight
+        env = {"CLAUDE_TIME_LATE_START": "22", "CLAUDE_TIME_LATE_END": "3"}
+        for hour in (22, 23, 0, 1, 2):
+            with self.subTest(hour=hour):
+                self.assertIn(
+                    "wrap-up",
+                    self._render_clean_env(_aware(2026, 5, 26, hour, 0), env),
+                )
+        for hour in (3, 14, 21):
+            with self.subTest(hour=hour):
+                self.assertNotIn(
+                    "wrap-up",
+                    self._render_clean_env(_aware(2026, 5, 26, hour, 0), env),
+                )
+
+    def test_dst_suffix_off_by_default(self):
+        # 2026 spring forward is March 8 — render on the day with NO env var
+        self.assertNotIn(
+            "DST", self._render_clean_env(_aware(2026, 3, 8, 10, 0))
+        )
+
+    def test_dst_suffix_us_region_fires_pre_2am_on_transition_day(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        # 1:30 AM on transition day — change is "tonight" (still upcoming)
+        out = self._render_clean_env(_aware(2026, 3, 8, 1, 30), env)
+        self.assertIn("DST spring-forward TONIGHT", out)
+
+    def test_dst_suffix_post_2am_on_transition_day_is_past_tense(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        # 10 AM on spring-forward day — clocks already changed at 2 AM
+        out = self._render_clean_env(_aware(2026, 3, 8, 10, 0), env)
+        self.assertIn("DST spring-forward happened earlier today", out)
+        self.assertNotIn("TONIGHT", out)
+
+    def test_dst_fall_back_pre_2am_on_transition_day(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        # Nov 1 2026 is the 1st Sunday — fall back transition day
+        out = self._render_clean_env(_aware(2026, 11, 1, 1, 30), env)
+        self.assertIn("DST fall-back TONIGHT", out)
+
+    def test_dst_fall_back_post_2am_on_transition_day(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        out = self._render_clean_env(_aware(2026, 11, 1, 10, 0), env)
+        self.assertIn("DST fall-back happened earlier today", out)
+
+    def test_dst_pre_transition_window_boundary(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        # 3 days before spring-forward (March 8) = March 5 — inside window
+        self.assertIn(
+            "DST spring-forward in 3d",
+            self._render_clean_env(_aware(2026, 3, 5, 10, 0), env),
+        )
+        # 4 days before = March 4 — outside window, silent
+        self.assertNotIn(
+            "DST", self._render_clean_env(_aware(2026, 3, 4, 10, 0), env)
+        )
+
+    def test_dst_post_transition_window_boundary(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        # 1 day after spring-forward — should fire with "started Nd ago"
+        self.assertIn(
+            "DST started 1d ago",
+            self._render_clean_env(_aware(2026, 3, 9, 10, 0), env),
+        )
+        # 3 days after — last day of window
+        self.assertIn(
+            "DST started 3d ago",
+            self._render_clean_env(_aware(2026, 3, 11, 10, 0), env),
+        )
+        # 4 days after — outside window, silent
+        self.assertNotIn(
+            "DST", self._render_clean_env(_aware(2026, 3, 12, 10, 0), env)
+        )
+
+    def test_dst_suffix_outside_window_silent(self):
+        env = {"CLAUDE_TIME_DST_REGION": "us"}
+        # July 1 is months from any transition
+        self.assertNotIn(
+            "DST", self._render_clean_env(_aware(2026, 7, 1, 10, 0), env)
+        )
+
+    def test_dst_region_case_insensitive(self):
+        env = {"CLAUDE_TIME_DST_REGION": "US"}
+        self.assertIn(
+            "DST", self._render_clean_env(_aware(2026, 3, 8, 10, 0), env)
+        )
+
+    def test_dst_region_unrecognized_value_is_silent(self):
+        env = {"CLAUDE_TIME_DST_REGION": "eu"}
+        self.assertNotIn(
+            "DST", self._render_clean_env(_aware(2026, 3, 8, 10, 0), env)
+        )
+
+    def test_both_suffixes_compose_with_semicolon(self):
+        env = {
+            "CLAUDE_TIME_LATE_START": "2",
+            "CLAUDE_TIME_LATE_END": "5",
+            "CLAUDE_TIME_DST_REGION": "us",
+        }
+        # Day before spring-forward, in the late window — both suffixes fire
+        # without the transition-time interaction
+        out = self._render_clean_env(_aware(2026, 3, 7, 3, 15), env)
+        self.assertIn("past late-hour wrap-up cutoff", out)
+        self.assertIn("DST spring-forward in 1d", out)
+        self.assertEqual(out.count(";"), 1)
+
+
+class DstTransitionTests(unittest.TestCase):
+    """The date math underlying the DST suffix."""
+
+    def test_spring_forward_2026(self):
+        # 2nd Sunday of March 2026 — should be March 8
+        transition, kind, _ = mod.closest_us_dst_transition(
+            datetime.date(2026, 3, 1)
+        )
+        self.assertEqual(transition, datetime.date(2026, 3, 8))
+        self.assertEqual(kind, "spring forward")
+
+    def test_fall_back_2026(self):
+        # 1st Sunday of November 2026 — should be November 1
+        transition, kind, _ = mod.closest_us_dst_transition(
+            datetime.date(2026, 10, 28)
+        )
+        self.assertEqual(transition, datetime.date(2026, 11, 1))
+        self.assertEqual(kind, "fall back")
+
+    def test_picks_just_passed_transition_when_closer(self):
+        # 2 days after spring forward: closest transition should still be
+        # the just-passed one, not the future fall-back
+        transition, kind, days_to = mod.closest_us_dst_transition(
+            datetime.date(2026, 3, 10)
+        )
+        self.assertEqual(kind, "spring forward")
+        self.assertEqual(days_to, -2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

New `UserPromptSubmit` hook (`hooks/inject-current-time.py`) that prepends a small bracketed system note with the current local time on every user message:

    [current time: 2026-05-26 14:04 EDT]

This closes the wall-clock-awareness gap caused by Claude's training cutoff. Without it the model cannot reliably distinguish "this morning" from "six months ago," judge whether a release / deploy / changelog entry is recent, or reason about urgency. Cost is ~12-25 tokens per turn depending on which (off-by-default) suffixes fire.

Two optional suffixes, both opt-in via environment variables set in the user's shell rc:

| Env var | Behavior |
|---------|----------|
| `CLAUDE_TIME_LATE_START` + `CLAUDE_TIME_LATE_END` (integer hours) | When both set and current hour is in `[start, end)`, appends `past late-hour wrap-up cutoff`. Supports midnight-spanning windows (e.g., `START=22 END=3` fires at 22, 23, 0, 1, 2). Self-care nudge for late-night coders. |
| `CLAUDE_TIME_DST_REGION=us` | Appends a US DST transition reminder within ±3 days of the spring-forward / fall-back transitions. On the transition day itself, the message flips from future-tense (`TONIGHT`) to past-tense (`happened earlier today`) once 2 AM local passes. Only `us` is implemented; non-US regions emit no suffix. |

Registers in `hooks/hooks.json` as a `UserPromptSubmit` entry via the existing `run-hook.cmd` cross-platform wrapper. Drains stdin to match the JSON-payload-consumption pattern used by the other hooks in this repo. Updates `README.md` (Hooks table + dedicated subsection documenting the env vars) and `CLAUDE.md` (plugin structure block).

## Test plan

- [ ] `python3 -m unittest hooks.test_inject_current_time` — all 20 cases pass
- [ ] After install + restart, every user prompt is prefixed with a bracketed `[current time: ...]` system note
- [ ] With no env vars set, the note contains only the bracketed timestamp (no suffixes)
- [ ] `CLAUDE_TIME_LATE_START=2 CLAUDE_TIME_LATE_END=5` → the `past late-hour wrap-up cutoff` suffix fires between 02:00 and 04:59 local
- [ ] `CLAUDE_TIME_LATE_START=22 CLAUDE_TIME_LATE_END=3` → fires at 22, 23, 0, 1, 2 (midnight-spanning case)
- [ ] `CLAUDE_TIME_DST_REGION=us` → DST nudge fires within ±3 days of the next US transition; on transition day itself, future-tense before 2 AM and past-tense after